### PR TITLE
新增修改后端url地址功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+./Client/lib/config.dart

--- a/Client/lib/main.dart
+++ b/Client/lib/main.dart
@@ -11,7 +11,9 @@ import 'package:xbt_client/utils/local_json.dart';
 // flutter build web --debug
 
 void main() async {
+  WidgetsFlutterBinding.ensureInitialized(); // 绑定初始化
   dio.interceptors.add(interceptorsWrapper);
+  await initBaseURL();
   runApp(const MyApp());
 }
 

--- a/Client/lib/pages/login_page.dart
+++ b/Client/lib/pages/login_page.dart
@@ -6,6 +6,7 @@ import 'package:xbt_client/utils/constants.dart';
 import 'package:xbt_client/utils/dio.dart';
 import 'package:xbt_client/utils/encode.dart';
 import 'package:xbt_client/utils/local_json.dart';
+import 'package:adaptive_dialog/adaptive_dialog.dart';
 
 class LoginPage extends StatefulWidget {
   final showBack;
@@ -110,6 +111,35 @@ class _LoginPageState extends State<LoginPage> {
                             Navigator.maybePop(context);
                           },
                           child: Text("返回")),
+                          // 添加分隔线和配置按钮
+                          Divider(height: 32),
+                          TextButton.icon(
+                            onPressed: () async {
+                              final result = await showTextInputDialog(
+                                context: context,
+                                title: '配置服务器地址',
+                                message: '请输入服务器地址',
+                                okLabel: '确定',
+                                cancelLabel: '取消',
+                                textFields: [
+                                  DialogTextField(
+                                    hintText: 'https://example.com',
+                                    initialText: await prefs.getString('base_url') ?? baseURL,
+                                  ),
+                                ],
+                              );
+                              if (result != null && result.isNotEmpty) {
+                                await prefs.setString('base_url', result[0]);
+                                baseURL = result[0]; // 直接更新当前运行时的baseURL
+                                SmartDialog.showNotify(
+                                  msg: "服务器地址已更新",
+                                  notifyType: NotifyType.success,
+                                );
+                              }
+                            },
+                            icon: Icon(Icons.settings),
+                            label: Text('配置服务器地址'),
+                          ),
                   ],
                 ),
               ),

--- a/Client/lib/utils/constants.dart
+++ b/Client/lib/utils/constants.dart
@@ -3,7 +3,12 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:xbt_client/config.dart';
 
-String baseURL = config_baseURL;
+late String baseURL;
+
+// 初始化baseURL
+Future<void> initBaseURL() async {
+  baseURL = (await prefs.getString('base_url')) ?? config_baseURL;
+}
 
 int activesLimit = 5;
 SharedPreferencesAsync prefs = SharedPreferencesAsync();


### PR DESCRIPTION
# 新增url 地址修改功能
在注册界面下方增加按钮“配置服务器地址”,点击后弹出配置弹窗
url地址储存在本地，当有储存在本地的url地址时将优先使用本地url，否则使用config.dart中地址
![3dc4e5b69f6b902c4a5665ee828f9b07](https://github.com/user-attachments/assets/b0fdff35-fb4d-48aa-92e6-943766423cad)
![6247f3dec602afa21a141e93d80b9729](https://github.com/user-attachments/assets/bee8b0d2-3485-4711-a5b7-61496e0b9a7d)

